### PR TITLE
Update CI to build dist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - main, master
   pull_request: {}
   merge_group:
     types: [checks_requested]


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change allows the CI workflow to trigger on pushes to both the `main` and `master` branches.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL6-R6): Modified the `push` event to include both `main` and `master` branches.